### PR TITLE
Add `ds` as optional parameter to agnosco flow

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -198,10 +198,13 @@ class Flow {
         reject('Missing acctNumber');
         return
       }
+      var req_json = { "acctNumber": obj.acctNumber };
 
-      let req = JSON.stringify({
-        "acctNumber": obj.acctNumber
-      });
+      if (obj.hasOwnProperty('ds')) {
+        req_json.ds = obj.ds;
+      }
+
+      let req = JSON.stringify(req_json);
 
       let FD = new FormData();
       FD.append('input', req);


### PR DESCRIPTION
To support co-brading `/preauth` and `/auth` needs to accept a `ds` parameter. See https://github.com/clearhaus/edss-go/pull/129

Invoke co-branding by adding `"ds": "<ds of your choise>"` to Agnosco JSON input form.

The standin service needs to have co-branded test ranges added for co-branding to be testable in sandbox.