### PR TITLE
Fake color depth when unsupported

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -422,7 +422,15 @@ class Flow {
     obj.browserJavaEnabled = navigator.javaEnabled()
     obj.browserJavascriptEnabled = true
     obj.browserLanguage = navigator.language
+
     obj.browserColorDepth = screen.colorDepth.toString()
+    if (![1, 4, 8, 15, 16, 24, 32, 48].includes(screen.colorDepth)) {
+      // Only the above color depths are allowed in the EMVCo spec.
+      // If we receive something else (e.g. 30 on macOS), we have to fake it.
+      console.log(`Color depth is ${screen.colorDepth}, faking it to 24`);
+      obj.browserColorDepth = "24"
+    }
+
     obj.browserScreenHeight = screen.height.toString()
     obj.browserScreenWidth = screen.width.toString()
     obj.browserTZ = new Date().getTimezoneOffset().toString()


### PR DESCRIPTION
The 3DS v2.2.0 spec (EMV 3-D Secure Protocol and Core Functions Specification v2.2.0, p. 173) does not allow other screen depth values than: 1, 4, 8, 15, 16, 24, 32, 48.

Most browsers will report 24 bit color depth even on 10-bit monitors (like Chrome), but Safari and Firefox on macOS report 30, resulting in an error similar to:

```json
{
  "errorCode": "203",
  "errorComponent": "S",
  "errorDescription": "Elements failed validation",
  "errorDetail": "browserColorDepth must be one of [1 4 8 15 16 24 32 48], received 30",
  "errorMessageType": "AReq",
  "messageType": "Erro",
  "messageVersion": "2.2.0",
  "threeDSServerTransID": "deadbeef-cafe-4bad-babe-feedfacec0de"
}
```

This fakes the color depth so satisfy EMVCo's requirements.

Luckily, 3DS v2.3.1 (EMV® 3-D Secure Protocol and Core Functions Specification v2.3.1.1, p. 213) allows any 2-digit number (as a string), but for now we need to support v2.2.0 as well. 

Faking it is also acceptable according to the v2.3.1 spec:

>Note: If an ACS does not support the value provided, then the ACS can use the closest supported value. For example, if the value provided = 30 and the ACS does not support that value, then the ACS could use the value = 24.