### PR TITLE
Document Chrome Local Network Access requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,10 @@ sends `threeDSCompInd: "N"`, which the Directory Server rejects with:
 You will also see a `LocalNetworkAccessDenied` CORS error in the browser
 console, and no `POST /3dsmethod/end` reaching the agnosco log.
 
-The iframe `allow="local-network"` delegation does **not** fix this, because
-the ACS callback is an auto-submitted cross-origin form POST, not a `fetch()`
-— so Chrome neither prompts nor honours the delegation. Allow it at the
-browser level instead. For local testing, disable the LNA check:
+For local testing, disable the LNA check:
 
 1. Open `chrome://flags/#local-network-access-check`.
 2. Set it to **Disabled** and restart Chrome.
-
-For a managed/shared setup, the persistent equivalent is the
-[`LocalNetworkAccessRestrictionsEnabled`](https://chromeenterprise.google/policies/local-network-access-restrictions-enabled/)
-enterprise policy (or origin-scoped
-[`LoopbackNetworkAccessAllowedForUrls`](https://chromeenterprise.google/policies/local-network-access-allowed-for-urls/)
-keyed on the sandbox ACS origins).
 
 ### Start the docker container
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,41 @@ it for SSL/TLS, either in a specific browser or system-wide.
 * On macOS, you can double-click the certificate to import it in Keychain
   Access, and change trust to be "Always Trust" for SSL.
 
+### First time setup: Chrome Local Network Access
+
+Recent versions of Chrome enforce
+[Local Network Access](https://developer.chrome.com/blog/local-network-access)
+(LNA), which blocks a public website from making requests to your local
+network. During a flow, the ACS pages (served from public origins, in hidden
+iframes) post their results back to agnosco on `127.0.0.1`
+(`/3dsmethod/end` after the 3DS method, `/challenge/end` after a challenge).
+Chrome blocks these public→loopback callbacks.
+
+If the callback is blocked, agnosco never sees the 3DS method complete and
+sends `threeDSCompInd: "N"`, which the Directory Server rejects with:
+
+```
+"errorCode": "305", "errorDescription": "Invalid ThreeDSCompInd",
+"errorDetail": "The threeDSCompInd must be \"Y\" when successful"
+```
+
+You will also see a `LocalNetworkAccessDenied` CORS error in the browser
+console, and no `POST /3dsmethod/end` reaching the agnosco log.
+
+The iframe `allow="local-network"` delegation does **not** fix this, because
+the ACS callback is an auto-submitted cross-origin form POST, not a `fetch()`
+— so Chrome neither prompts nor honours the delegation. Allow it at the
+browser level instead. For local testing, disable the LNA check:
+
+1. Open `chrome://flags/#local-network-access-check`.
+2. Set it to **Disabled** and restart Chrome.
+
+For a managed/shared setup, the persistent equivalent is the
+[`LocalNetworkAccessRestrictionsEnabled`](https://chromeenterprise.google/policies/local-network-access-restrictions-enabled/)
+enterprise policy (or origin-scoped
+[`LoopbackNetworkAccessAllowedForUrls`](https://chromeenterprise.google/policies/local-network-access-allowed-for-urls/)
+keyed on the sandbox ACS origins).
+
 ### Start the docker container
 
 ```bash


### PR DESCRIPTION
## Why

Testing flows against `serviceN.sandbox.3dsecure.io` can fail with Directory Server **error 305** (`Invalid ThreeDSCompInd` — "must be \"Y\" when successful"), even though the request and the 3DS-method flow are correct.

The root cause is Chrome's **Local Network Access** policy. The ACS pages run in hidden iframes served from **public** origins, and they post their completion back to agnosco on `127.0.0.1` (`/3dsmethod/end`, `/challenge/end`). Chrome blocks these public→loopback callbacks (`LocalNetworkAccessDenied`), so agnosco never sees the 3DS method complete and sends `threeDSCompInd: "N"` → DS rejects it.

There is no fix in agnosco's page code: the callback is an auto-submitted cross-origin **form POST**, so the iframe `allow="local-network"` delegation and the LNA permission prompt (which target `fetch(..., {targetAddressSpace})`) don't apply. The fix has to be at the browser-config level.

## What

Documents the symptom and the fix in the README:
- Disable `chrome://flags/#local-network-access-check` for local testing.
- Use the `LocalNetworkAccessRestrictionsEnabled` / `LoopbackNetworkAccessAllowedForUrls` enterprise policies for managed/shared setups.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)